### PR TITLE
Fix bios directory in PCSX2 Guide

### DIFF
--- a/wiki-rtd/docs/wiki_emulator_guides/pcsx2/pcsx2-guide.md
+++ b/wiki-rtd/docs/wiki_emulator_guides/pcsx2/pcsx2-guide.md
@@ -21,7 +21,7 @@ PCSX2 supports the following formats: `ISO` `BIN with CUE files` `CHD`
 
 ## Does PCSX2 require BIOS or Firmware?
 
-Yes, they need to be put directly into the `retrodeck/roms/bios/` without any subfolder.
+Yes, they need to be put directly into the `retrodeck/bios/` without any subfolder.
 
 
 ## How to enable/disable Multitap?


### PR DESCRIPTION
Change directory from `retrodeck/roms/bios/` to `retrodeck/bios/`